### PR TITLE
Support for `buildRomData()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for `buildRomData()` allowing ROM data processing indirection (eg: zip support).
 
 ### Changed
 
@@ -18,12 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 *
-
-## [0.9.3] - 2023-10-30
-
-### Added
-
-* Support for `buildRomData()` allowing ROM data processing indirection (eg: zip support).
 
 ## [0.9.2] - 2023-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for `buildRomData()` allowing ROM data processing indirection (eg: zip support).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Support for `buildRomData()` allowing ROM data processing indirection (eg: zip support).
+*
 
 ### Changed
 
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 *
+
+## [0.9.3] - 2023-10-30
+
+### Added
+
+* Support for `buildRomData()` allowing ROM data processing indirection (eg: zip support).
 
 ## [0.9.2] - 2023-09-22
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "emukit",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "description": "Emulation Web UI toolkit",
     "repository": {
         "type": "git",

--- a/react/app.tsx
+++ b/react/app.tsx
@@ -547,9 +547,7 @@ export const EmulatorApp: FC<EmulatorAppProps> = ({
             return;
         }
 
-        const arrayBuffer = await file.arrayBuffer();
-        const romData = new Uint8Array(arrayBuffer);
-
+        const romData = await emulator.buildRomData(file);
         emulator.boot({ engine: null, romName: file.name, romData: romData });
 
         showToast(`Loaded ${file.name} ROM successfully!`);

--- a/react/app.tsx
+++ b/react/app.tsx
@@ -549,7 +549,6 @@ export const EmulatorApp: FC<EmulatorAppProps> = ({
 
         const romData = await emulator.buildRomData(file);
         emulator.boot({ engine: null, romName: file.name, romData: romData });
-
         showToast(`Loaded ${file.name} ROM successfully!`);
     };
     const onPauseClick = () => {

--- a/react/app.tsx
+++ b/react/app.tsx
@@ -653,8 +653,7 @@ export const EmulatorApp: FC<EmulatorAppProps> = ({
         showToast(`Deleted save state #${index} successfully!`);
     };
     const onUploadFile = async (file: File) => {
-        const arrayBuffer = await file.arrayBuffer();
-        const romData = new Uint8Array(arrayBuffer);
+        const romData = await emulator.buildRomData(file);
         emulator.boot({ engine: null, romName: file.name, romData: romData });
         showToast(`Loaded ${file.name} ROM successfully!`);
     };

--- a/react/structs.ts
+++ b/react/structs.ts
@@ -376,10 +376,10 @@ export interface Emulator extends ObservableI {
      * Processes the provided file instance as a ROM file and
      * returns the raw data of the ROM file, ready to be fed to
      * the emulator.
-     * 
-     * This method can be used to process the file and handle
+     *
+     * This method can be used to process the file, handling
      * features like compression (eg: zip files).
-     * 
+     *
      * @param file The file instance to be processed as a ROM.
      * @returns The raw data of the ROM file.
      */
@@ -389,13 +389,29 @@ export interface Emulator extends ObservableI {
      * Serializes the current state of the emulator into a
      * data buffer that can be used to store the state in
      * a persistent storage.
-     * 
+     *
      * @returns The serialized state of the emulator.
      */
     serializeState?(): Uint8Array;
 
+    /**
+     * Deserializes the sate data buffer, loading the contents
+     * of it into the current emulator instance.
+     *
+     * @param data The saved state data buffer, that is going
+     * to be loaded into the emulator instance.
+     */
     unserializeState?(data: Uint8Array): void;
 
+    /**
+     * Builds the state of the emulator from the given data
+     * and index, this method should be able to build the
+     * state from the given data.
+     *
+     * @param index The saved state index to be built.
+     * @param data The saved state data buffer, that is going
+     * to be used in the building of the state.
+     */
     buildState?(index: number, data: Uint8Array): SaveState;
 
     /**

--- a/react/structs.ts
+++ b/react/structs.ts
@@ -372,6 +372,26 @@ export interface Emulator extends ObservableI {
 
     keyLift(key: string): void;
 
+    /**
+     * Processes the provided file instance as a ROM file and
+     * returns the raw data of the ROM file, ready to be fed to
+     * the emulator.
+     * 
+     * This method can be used to process the file and handle
+     * features like compression (eg: zip files).
+     * 
+     * @param file The file instance to be processed as a ROM.
+     * @returns The raw data of the ROM file.
+     */
+    buildRomData(file: File): Promise<Uint8Array>;
+
+    /**
+     * Serializes the current state of the emulator into a
+     * data buffer that can be used to store the state in
+     * a persistent storage.
+     * 
+     * @returns The serialized state of the emulator.
+     */
     serializeState?(): Uint8Array;
 
     unserializeState?(data: Uint8Array): void;
@@ -637,6 +657,12 @@ export class EmulatorBase extends Observable {
 
     set handlers(value: Handlers) {
         this._handlers = value;
+    }
+
+    async buildRomData(file: File): Promise<Uint8Array> {
+        const arrayBuffer = await file.arrayBuffer();
+        const romData = new Uint8Array(arrayBuffer);
+        return romData;
     }
 
     serializeState(): Uint8Array {


### PR DESCRIPTION
## Description

Adds indirection support to be able to handle base ROM data.
Good for instance for Zip file processing.