### PR TITLE
Support for main loop inversion of control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for inversion of game loop control
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     },
     "source": "index.ts",
     "peerDependencies": {
-        "@types/react": "^18.2.25",
+        "@types/react": "^18.3.3",
         "@types/react-dom": "^18.2.11",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
     },
     "devDependencies": {
-        "@types/react": "^18.2.25",
-        "@types/react-dom": "^18.2.11",
-        "@typescript-eslint/eslint-plugin": "^6.7.4",
-        "@typescript-eslint/parser": "^6.7.4",
-        "eslint": "^8.51.0",
-        "mocha": "^10.2.0",
-        "prettier": "^3.0.3",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "typescript": "^5.2.2"
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@typescript-eslint/eslint-plugin": "^7.13.1",
+        "@typescript-eslint/parser": "^7.13.1",
+        "eslint": "^8.57.0",
+        "mocha": "^10.4.0",
+        "prettier": "^3.3.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "typescript": "^5.4.5"
     }
 }

--- a/ts/structs.ts
+++ b/ts/structs.ts
@@ -4,6 +4,13 @@ import { Logger, logger } from "./logging.ts";
 
 export const FREQUENCY_DELTA = 100000;
 
+/**
+ * The frequency of the pause polling update operation,
+ * increasing this value will make resume from emulation
+ * paused state fasted.
+ */
+export const IDLE_HZ = 10;
+
 export type Callback<T> = (owner: T, params?: unknown) => void;
 
 export type RomInfo = {
@@ -761,13 +768,14 @@ export class EmulatorBase extends Observable {
 /**
  * Emulator logic implementation meant to be used as a starting point
  * to have an inversion of control in terms of event loop.
- * 
+ *
  * Any emulator implementation should be able to extend this class
  * and avoid implementing the main game loop logic.
  */
 export class EmulatorLogic extends EmulatorBase {
-    private paused = false;
-    private nextTickTime = 0;
+    protected paused = false;
+    protected nextTickTime = 0;
+    protected idleFrequency = IDLE_HZ;
 
     /**
      * Runs the initialization and main loop execution for the emulator.
@@ -828,7 +836,7 @@ export class EmulatorLogic extends EmulatorBase {
                     messageNormalized.startsWith("unreachable") ||
                     messageNormalized.startsWith("recursive use of an object");
                 if (isPanic) {
-                    message = "Unrecoverable error, restarting Game Boy";
+                    message = "Unrecoverable error, restarting emulator";
                 }
 
                 // displays the error information to both the end-user
@@ -866,6 +874,11 @@ export class EmulatorLogic extends EmulatorBase {
                 setTimeout(resolve, pendingTime);
             });
         }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    boot(options: unknown) {
+        throw new Error("Not implemented");
     }
 
     toggleRunning() {

--- a/ts/structs.ts
+++ b/ts/structs.ts
@@ -821,7 +821,10 @@ export class EmulatorLogic extends EmulatorBase {
         // ROM retrieved from a remote data source
         await this.boot({ loadRom: true, romPath: romUrl ?? undefined });
 
-        this.bind("frame", () => {  
+        // binds the frame event to the current instance of the
+        // emulator logic, this event is going to be used to
+        // calculate the number of frames per second (FPS)
+        this.bind("frame", () => {
             // increments the current frame count (as new frame exists)
             // and in case the target number of frames for FPS control
             // has been reached calculates the number of FPS and
@@ -923,8 +926,7 @@ export class EmulatorLogic extends EmulatorBase {
         }
     }
 
-    async stop() {
-    }
+    async stop() {}
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     boot(options: unknown) {

--- a/ts/structs.ts
+++ b/ts/structs.ts
@@ -822,7 +822,7 @@ export class EmulatorLogic extends EmulatorBase {
      */
     async start({
         romUrl,
-        loopMode = LoopMode.AnimationFrame
+        loopMode = LoopMode.SetTimeout
     }: {
         romUrl?: string;
         loopMode?: LoopMode;


### PR DESCRIPTION
## Description

Generationalisation that inverts the control of primary game loop ownership.

It has the potential to break some compatibility.

## Pending

This is the list of changes that are still pending:

- [x]  Removal of the Gameboy code references
- [x]  Loop syncing strategy (`nextTickTime` in emukit)
- [x] Adaptation of chip-ahoyto and battlerust
- [x] Usage of the `window.requestAnimationFrame(step)` logic